### PR TITLE
handle other regions

### DIFF
--- a/aws/mordor/cfn-templates/c2-server-template.json
+++ b/aws/mordor/cfn-templates/c2-server-template.json
@@ -46,9 +46,22 @@
     },
     "Mappings" : {
         "UbuntuAWSRegionArch2AMI" : {
-            "us-east-1" : { "HVM64" : "ami-064a0193585662d74" },
-            "us-west-1" : { "HVM64" : "ami-056d04da775d124d7" },
-            "us-west-2" : { "HVM64" : "ami-09a3d8a7177216dcf" }
+            "eu-north-1"        : {"HVM64": "ami-c37bf0bd" },
+            "ap-south-1"        : {"HVM64": "ami-0cf8402efdb171312" },
+            "eu-west-3"        : {"HVM64": "ami-033e0056c336ecff0" },
+            "eu-west-2"        : {"HVM64": "ami-0a7c91b6616d113b1" },
+            "eu-west-1"        : {"HVM64": "ami-01cca82393e531118" },
+            "ap-northeast-2"        : {"HVM64": "ami-081626bfb3fbc9f49" },
+            "ap-northeast-1"        : {"HVM64": "ami-0cb1c8cab7f5249b6" },
+            "sa-east-1"        : {"HVM64": "ami-094c359b4d8c6a8ca" },
+            "ca-central-1"        : {"HVM64": "ami-0bc1dd4eb012a451e" },
+            "ap-southeast-1"        : {"HVM64": "ami-099d318f80eab7e94" },
+            "ap-southeast-2"        : {"HVM64": "ami-08a648fb5cc86fb74" },
+            "eu-central-1"        : {"HVM64": "ami-0cdab515472ca0bac" },
+            "us-east-1"        : {"HVM64": "ami-064a0193585662d74" },
+            "us-east-2"        : {"HVM64": "ami-021b7b04f1ac696c2" },
+            "us-west-1"        : {"HVM64": "ami-056d04da775d124d7" },
+            "us-west-2"        : {"HVM64": "ami-09a3d8a7177216dcf" }
         }
     },
     "Resources" : {

--- a/aws/mordor/cfn-templates/ec2-network-template.json
+++ b/aws/mordor/cfn-templates/ec2-network-template.json
@@ -34,7 +34,20 @@
         "AWSRegion2AZ" : {
             "us-east-1" : { "1" : "us-east-1b", "2" : "us-east-1c", "3" : "us-east-1d", "4" : "us-east-1e", "5" : "us-east-1f" },
             "us-west-1" : { "1" : "us-west-1b", "2" : "us-west-1c" },
-            "us-west-2" : { "1" : "us-west-2a", "2" : "us-west-2b", "3" : "us-west-2c"  }
+            "us-west-2" : { "1" : "us-west-2a", "2" : "us-west-2b", "3" : "us-west-2c"  },
+            "eu-north-1" : { "1" : "eu-north-1a"},
+            "ap-south-1" : { "1" : "ap-south-1a"},
+            "ap-northeast-2" : { "1" : "ap-northeast-2a"},
+            "ap-northeast-1" : { "1" : "ap-northeast-1a"},
+            "sa-east-1" : { "1" : "sa-east-1a"},
+            "ca-central-1" : { "1" : "ca-central-1a"},
+            "ap-southeast-1" : { "1" : "ap-southeast-1a"},
+            "ap-southeast-2" : { "1" : "ap-southeast-2a"},
+            "eu-central-1" : { "1" : "eu-central-1a"},
+            "eu-west-3" : { "1" : "eu-west-3a"},
+            "eu-west-2" : { "1" : "us-west-2a"},
+            "eu-west-1" : { "1" : "eu-west-1a"},
+            "us-east-2" : { "1" : "us-east-2a"}
         }
     },
     "Resources" : {

--- a/aws/mordor/cfn-templates/helk-server-template.json
+++ b/aws/mordor/cfn-templates/helk-server-template.json
@@ -53,9 +53,22 @@
     },
     "Mappings" : {
         "UbuntuAWSRegionArch2AMI" : {
-            "us-east-1" : { "HVM64" : "ami-064a0193585662d74" },
-            "us-west-1" : { "HVM64" : "ami-056d04da775d124d7" },
-            "us-west-2" : { "HVM64" : "ami-09a3d8a7177216dcf" }
+            "eu-north-1"        : {"HVM64": "ami-c37bf0bd" },
+            "ap-south-1"        : {"HVM64": "ami-0cf8402efdb171312" },
+            "eu-west-3"        : {"HVM64": "ami-033e0056c336ecff0" },
+            "eu-west-2"        : {"HVM64": "ami-0a7c91b6616d113b1" },
+            "eu-west-1"        : {"HVM64": "ami-01cca82393e531118" },
+            "ap-northeast-2"        : {"HVM64": "ami-081626bfb3fbc9f49" },
+            "ap-northeast-1"        : {"HVM64": "ami-0cb1c8cab7f5249b6" },
+            "sa-east-1"        : {"HVM64": "ami-094c359b4d8c6a8ca" },
+            "ca-central-1"        : {"HVM64": "ami-0bc1dd4eb012a451e" },
+            "ap-southeast-1"        : {"HVM64": "ami-099d318f80eab7e94" },
+            "ap-southeast-2"        : {"HVM64": "ami-08a648fb5cc86fb74" },
+            "eu-central-1"        : {"HVM64": "ami-0cdab515472ca0bac" },
+            "us-east-1"        : {"HVM64": "ami-064a0193585662d74" },
+            "us-east-2"        : {"HVM64": "ami-021b7b04f1ac696c2" },
+            "us-west-1"        : {"HVM64": "ami-056d04da775d124d7" },
+            "us-west-2"        : {"HVM64": "ami-09a3d8a7177216dcf" }
         }
     },
     "Resources" : {

--- a/aws/mordor/cfn-templates/windows-dc-template.json
+++ b/aws/mordor/cfn-templates/windows-dc-template.json
@@ -105,9 +105,22 @@
     },
     "Mappings" : {
         "WindowsServerAWSRegionArch2AMI" : {
-            "us-east-1" : { "HVM64" : "ami-06a4e829b8bbad61e" },
-            "us-west-1" : { "HVM64" : "ami-0069635df219ce9e5" },
-            "us-west-2" : { "HVM64" : "ami-04ad37d2932b886c0" }
+            "eu-north-1"        : {"HVM64": "ami-0a1ec014926fa9fdd" },
+            "ap-south-1"        : {"HVM64": "ami-00b2d3ea9077fcebf" },
+            "eu-west-3"        : {"HVM64": "ami-0109f669f0155fac6" },
+            "eu-west-2"        : {"HVM64": "ami-0101530e3e27a39e9" },
+            "eu-west-1"        : {"HVM64": "ami-00b49e2d0e1fc7fad" },
+            "ap-northeast-2"        : {"HVM64": "ami-066eac07824e13596" },
+            "ap-northeast-1"        : {"HVM64": "ami-0342e79d2629aa47f" },
+            "sa-east-1"        : {"HVM64": "ami-0f203ed70c367edf5" },
+            "ca-central-1"        : {"HVM64": "ami-08b0035504b87a83f" },
+            "ap-southeast-1"        : {"HVM64": "ami-0331481cc4fdd340b" },
+            "ap-southeast-2"        : {"HVM64": "ami-0d692d1b5e7f63b6a" },
+            "eu-central-1"        : {"HVM64": "ami-089ca11903ef1567b" },
+            "us-east-1"        : {"HVM64": "ami-06a4e829b8bbad61e" },
+            "us-east-2"        : {"HVM64": "ami-017894519635aafd2" },
+            "us-west-1"        : {"HVM64": "ami-0069635df219ce9e5" },
+            "us-west-2"        : {"HVM64": "ami-04ad37d2932b886c0" }
         }
     },
     "Resources" : {
@@ -356,7 +369,7 @@
                         "commands": {
                             "a-signal-success": {
                                 "command": {
-                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource DomainController1 --stack ", { "Ref": "AWS::StackName" } ]]
+                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource DomainController1 --stack ", { "Ref": "AWS::StackName" },  " --region ", { "Ref" : "AWS::Region" } ]]
                                 },
                                 "waitAfterCompletion": "0"
                             }

--- a/aws/mordor/cfn-templates/windows-servers-template.json
+++ b/aws/mordor/cfn-templates/windows-servers-template.json
@@ -103,9 +103,22 @@
     },
     "Mappings" : {
         "WindowsServerAWSRegionArch2AMI" : {
-            "us-east-1" : { "HVM64" : "ami-06a4e829b8bbad61e" },
-            "us-west-1" : { "HVM64" : "ami-0069635df219ce9e5" },
-            "us-west-2" : { "HVM64" : "ami-04ad37d2932b886c0" }
+            "eu-north-1"        : {"HVM64": "ami-0a1ec014926fa9fdd" },
+            "ap-south-1"        : {"HVM64": "ami-00b2d3ea9077fcebf" },
+            "eu-west-3"        : {"HVM64": "ami-0109f669f0155fac6" },
+            "eu-west-2"        : {"HVM64": "ami-0101530e3e27a39e9" },
+            "eu-west-1"        : {"HVM64": "ami-00b49e2d0e1fc7fad" },
+            "ap-northeast-2"        : {"HVM64": "ami-066eac07824e13596" },
+            "ap-northeast-1"        : {"HVM64": "ami-0342e79d2629aa47f" },
+            "sa-east-1"        : {"HVM64": "ami-0f203ed70c367edf5" },
+            "ca-central-1"        : {"HVM64": "ami-08b0035504b87a83f" },
+            "ap-southeast-1"        : {"HVM64": "ami-0331481cc4fdd340b" },
+            "ap-southeast-2"        : {"HVM64": "ami-0d692d1b5e7f63b6a" },
+            "eu-central-1"        : {"HVM64": "ami-089ca11903ef1567b" },
+            "us-east-1"        : {"HVM64": "ami-06a4e829b8bbad61e" },
+            "us-east-2"        : {"HVM64": "ami-017894519635aafd2" },
+            "us-west-1"        : {"HVM64": "ami-0069635df219ce9e5" },
+            "us-west-2"        : {"HVM64": "ami-04ad37d2932b886c0" }
         }
     },
     "Resources" : {
@@ -282,7 +295,7 @@
                         "commands": {
                             "a-signal-success": {
                                 "command": {
-                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource WEC --stack ", { "Ref": "AWS::StackName" } ]]
+                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource WEC --stack ", { "Ref": "AWS::StackName" },  " --region ", { "Ref" : "AWS::Region" }  ]]
                                 },
                                 "waitAfterCompletion": "0"
                             }
@@ -504,7 +517,7 @@
                         "commands": {
                             "a-signal-success": {
                                 "command": {
-                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource FILEServer --stack ", { "Ref": "AWS::StackName" } ]]
+                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource FILEServer --stack ", { "Ref": "AWS::StackName" },  " --region ", { "Ref" : "AWS::Region" }]]
                                 },
                                 "waitAfterCompletion": "0"
                             }

--- a/aws/mordor/cfn-templates/windows-workstations-template.json
+++ b/aws/mordor/cfn-templates/windows-workstations-template.json
@@ -160,22 +160,22 @@
     },
     "Mappings" : {
         "WindowsWorkstationAWSRegionArch2AMI" : {
-            "us-east-1" : { "HVM64" : "ami-0954cc8e05b5ab1ba"},
-            "eu-north-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "ap-south-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "eu-west-3"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "eu-west-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "eu-west-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "ap-northeast-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "ap-northeast-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "sa-east-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "ca-central-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "ap-southeast-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "ap-southeast-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "eu-central-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "us-east-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "us-west-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
-            "us-west-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" }
+            "eu-north-1"        : {"HVM64": "ami-0a1ec014926fa9fdd" },
+            "ap-south-1"        : {"HVM64": "ami-00b2d3ea9077fcebf" },
+            "eu-west-3"        : {"HVM64": "ami-0109f669f0155fac6" },
+            "eu-west-2"        : {"HVM64": "ami-0101530e3e27a39e9" },
+            "eu-west-1"        : {"HVM64": "ami-00b49e2d0e1fc7fad" },
+            "ap-northeast-2"        : {"HVM64": "ami-066eac07824e13596" },
+            "ap-northeast-1"        : {"HVM64": "ami-0342e79d2629aa47f" },
+            "sa-east-1"        : {"HVM64": "ami-0f203ed70c367edf5" },
+            "ca-central-1"        : {"HVM64": "ami-08b0035504b87a83f" },
+            "ap-southeast-1"        : {"HVM64": "ami-0331481cc4fdd340b" },
+            "ap-southeast-2"        : {"HVM64": "ami-0d692d1b5e7f63b6a" },
+            "eu-central-1"        : {"HVM64": "ami-089ca11903ef1567b" },
+            "us-east-1"        : {"HVM64": "ami-06a4e829b8bbad61e" },
+            "us-east-2"        : {"HVM64": "ami-017894519635aafd2" },
+            "us-west-1"        : {"HVM64": "ami-0069635df219ce9e5" },
+            "us-west-2"        : {"HVM64": "ami-04ad37d2932b886c0" }
         }
     },
     "Resources" : {

--- a/aws/mordor/cfn-templates/windows-workstations-template.json
+++ b/aws/mordor/cfn-templates/windows-workstations-template.json
@@ -160,7 +160,22 @@
     },
     "Mappings" : {
         "WindowsWorkstationAWSRegionArch2AMI" : {
-            "us-east-1" : { "HVM64" : "ami-0954cc8e05b5ab1ba"}
+            "us-east-1" : { "HVM64" : "ami-0954cc8e05b5ab1ba"},
+            "eu-north-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "ap-south-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "eu-west-3"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "eu-west-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "eu-west-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "ap-northeast-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "ap-northeast-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "sa-east-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "ca-central-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "ap-southeast-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "ap-southeast-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "eu-central-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "us-east-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "us-west-1"        : {"HVM64": "ami-xxxxxxxxxxxxx" },
+            "us-west-2"        : {"HVM64": "ami-xxxxxxxxxxxxx" }
         }
     },
     "Resources" : {
@@ -346,7 +361,7 @@
                         "commands": {
                             "a-signal-success": {
                                 "command": {
-                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource HRWKS --stack ", { "Ref": "AWS::StackName" } ]]
+                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource HRWKS --stack ", { "Ref": "AWS::StackName" },  " --region ", { "Ref" : "AWS::Region" }]]
                                 },
                                 "waitAfterCompletion": "0"
                             }
@@ -553,7 +568,7 @@
                         "commands": {
                             "a-signal-success": {
                                 "command": {
-                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource ITWKS --stack ", { "Ref": "AWS::StackName" } ]]
+                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource ITWKS --stack ", { "Ref": "AWS::StackName" },  " --region ", { "Ref" : "AWS::Region" }]]
                                 },
                                 "waitAfterCompletion": "0"
                             }
@@ -760,7 +775,7 @@
                         "commands": {
                             "a-signal-success": {
                                 "command": {
-                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource ACCTWKS --stack ", { "Ref": "AWS::StackName" } ]]
+                                    "Fn::Join": ["", [ "cfn-signal.exe -e %ERRORLEVEL% --resource ACCTWKS --stack ", { "Ref": "AWS::StackName" },  " --region ", { "Ref" : "AWS::Region" }]]
                                 },
                                 "waitAfterCompletion": "0"
                             }

--- a/aws/mordor/deploy-mordor.sh
+++ b/aws/mordor/deploy-mordor.sh
@@ -15,7 +15,7 @@ usage(){
     echo "Examples:"
     echo " $0 -e 'shire'    Deploy Mordor Shire environment"
     echo " $0 -e 'erebor'   Deploy Mordor Erebor environment"
-    echo " $0 -e 'shire' -r '$MORDOR_REGION'   Deploy Mordor Erebor environment on a specific region (us-east-1 if not specified)"
+    echo " $0 -e 'shire' -r 'your-region'   Deploy Mordor Erebor environment on a specific region (us-east-1 if not specified)"
     echo " "
     exit 1
 }

--- a/aws/mordor/deploy-mordor.sh
+++ b/aws/mordor/deploy-mordor.sh
@@ -9,25 +9,28 @@ usage(){
     echo "Usage: $0 [option...]" >&2
     echo
     echo "   -e             set mordor environment to build"
+    echo "   -r             set region"
     echo "   -h             Prints this message"
     echo
     echo "Examples:"
     echo " $0 -e 'shire'    Deploy Mordor Shire environment"
     echo " $0 -e 'erebor'   Deploy Mordor Erebor environment"
+    echo " $0 -e 'shire' -r '$MORDOR_REGION'   Deploy Mordor Erebor environment on a specific region (us-east-1 if not specified)"
     echo " "
     exit 1
 }
 
 # ************ Command Options **********************
-while getopts e:h option
+MORDOR_REGION="us-east-1"
+while getopts e:r:h option
 do
     case "${option}"
     in
         e) MORDOR_ENVIRONMENT=$OPTARG;;
+        r) MORDOR_REGION=$OPTARG;;
         h | [?]) usage ; exit;;
     esac
 done
-
 
 # *********** Validating subscription Input ***************
 case $MORDOR_ENVIRONMENT in
@@ -46,46 +49,46 @@ echo "================================="
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] Creating MordorNetworkStack .."
 echo " "
-aws --region us-east-1 cloudformation create-stack --stack-name MordorNetworkStack --template-body file://./cfn-templates/ec2-network-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/ec2-network-parameters.json
+aws --region $MORDOR_REGION cloudformation create-stack --stack-name MordorNetworkStack --template-body file://./cfn-templates/ec2-network-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/ec2-network-parameters.json
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] EC2 Network stack template has been sent over to AWS and it is being processed remotely .."
 echo "[MORDOR-CLOUDFORMATION-INFO] All other instances depend on it."
 echo "[MORDOR-CLOUDFORMATION-INFO] Waiting for MordorNetworkStack to be created.."
 echo " "
-aws --region us-east-1 cloudformation wait stack-create-complete --stack-name MordorNetworkStack
+aws --region $MORDOR_REGION cloudformation wait stack-create-complete --stack-name MordorNetworkStack
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] MordorNetworkStack was created."
 echo "[MORDOR-CLOUDFORMATION-INFO] Creating MordorHELKStack .."
 echo " "
-aws --region us-east-1 cloudformation create-stack --stack-name MordorHELKStack --template-body file://./cfn-templates/helk-server-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/helk-server-parameters.json
+aws --region $MORDOR_REGION cloudformation create-stack --stack-name MordorHELKStack --template-body file://./cfn-templates/helk-server-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/helk-server-parameters.json
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] HELK stack template has been sent over to AWS and it is being processed remotely .."
 echo "[MORDOR-CLOUDFORMATION-INFO] Creating MordorC2Stack .."
 echo " "
-aws --region us-east-1 cloudformation create-stack --stack-name MordorC2Stack --template-body file://./cfn-templates/c2-server-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/c2-server-parameters.json
+aws --region $MORDOR_REGION cloudformation create-stack --stack-name MordorC2Stack --template-body file://./cfn-templates/c2-server-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/c2-server-parameters.json
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] C2 stack template has been sent over to AWS and it is being processed remotely .."
 echo "[MORDOR-CLOUDFORMATION-INFO] Creating MordorWindowsDCStack .."
 echo " "
-aws --region us-east-1 cloudformation create-stack --stack-name MordorWindowsDCStack --template-body file://./cfn-templates/windows-dc-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/windows-dc-parameters.json
+aws --region $MORDOR_REGION cloudformation create-stack --stack-name MordorWindowsDCStack --on-failure DO_NOTHING --template-body file://./cfn-templates/windows-dc-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/windows-dc-parameters.json
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] DC stack template has been sent over to AWS and it is being processed remotely .."
 echo "[MORDOR-CLOUDFORMATION-INFO] All other Windows instances depend on it."
 echo "[MORDOR-CLOUDFORMATION-INFO] Waiting for MordorWindowsDCStack to be created.."
 echo " "
-aws --region us-east-1 cloudformation wait stack-create-complete --stack-name MordorWindowsDCStack
+aws --region $MORDOR_REGION cloudformation wait stack-create-complete --stack-name MordorWindowsDCStack
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] MordorWindowsDCStack was created."
 echo "[MORDOR-CLOUDFORMATION-INFO] Creating MordorWindowsServersStack .."
 echo " "
-aws --region us-east-1 cloudformation create-stack --stack-name MordorWindowsServersStack --template-body file://./cfn-templates/windows-servers-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/windows-servers-parameters.json
+aws --region $MORDOR_REGION cloudformation create-stack --stack-name MordorWindowsServersStack --template-body file://./cfn-templates/windows-servers-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/windows-servers-parameters.json
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] Servers stack template has been sent over to AWS and it is being processed remotely .."
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] Creating MordorWindowsWorkstationsStack .."
-aws --region us-east-1 cloudformation create-stack --stack-name MordorWindowsWorkstationsStack --template-body file://./cfn-templates/windows-workstations-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/windows-workstations-parameters.json
+aws --region $MORDOR_REGION cloudformation create-stack --stack-name MordorWindowsWorkstationsStack --template-body file://./cfn-templates/windows-workstations-template.json --parameters file://./cfn-parameters/$MORDOR_ENVIRONMENT/windows-workstations-parameters.json
 echo " "
 echo "[MORDOR-CLOUDFORMATION-INFO] Workstations stack template has been sent over to AWS and it is being processed remotely .."
 echo "[MORDOR-CLOUDFORMATION-INFO] No other stack depends on Workstations or Servers"
 echo "[MORDOR-CLOUDFORMATION-INFO] You can track deployment progress via your CloudFormation Console"
-echo "[MORDOR-CLOUDFORMATION-INFO] CloudFormation Console: https://console.aws.amazon.com/cloudformation/home?region=us-east-1 "
+echo "[MORDOR-CLOUDFORMATION-INFO] CloudFormation Console: https://console.aws.amazon.com/cloudformation/home?region=$MORDOR_REGION "


### PR DESCRIPTION
Hi Cyb3rWard0g, we can now deploy Mordor environments on other regions :)

When your custom AMI (used for workstations stack) "us-east-1" : { "HVM64" : "ami-0954cc8e05b5ab1ba"} will be copied on all other regions, i will update the file windows-workstations-template.json with the corresponding AMI IDs on other regions.

FYI : My tests were done with my custom AMI created from an instance deployed using the custom AMI ami-0954cc8e05b5ab1ba, then i copied my custom AMI on other regions.

