### PR TITLE
Update Add-DomainUsers.ps1

### DIFF
--- a/resources/scripts/powershell/active-directory/Add-DomainUsers.ps1
+++ b/resources/scripts/powershell/active-directory/Add-DomainUsers.ps1
@@ -58,7 +58,7 @@ Ring,Mordor,mordorsvc,IT Support,Service Account,Th3K1ng!1122,Users,DomainUsers
 write-host "Creating domain users.."
 $domainUsers | ConvertFrom-Csv | ForEach-Object {
     $UserPrincipalName = $_.SamAccountName + "@" + $domainFQDN
-    $DisplayName = $_.LastName + " " + $_.FirstName
+    $DisplayName = $_.FirstName + " " + $_.LastName
     $OUPath = "OU="+$_.UserContainer+",DC=$DomainName1,DC=$DomainName2"
     $SamAccountName = $_.SamAccountName
     $ServiceName = $_.FirstName


### PR DESCRIPTION
I noticed on a recent deployment that the users get created with Display names as "LastName FirstName", and wanted to propose making them "FirstName LastName".  I know it's a small nit-picky detail, just makes user data a bit easier to look at.